### PR TITLE
fix the rotation matrix of cell

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -362,7 +362,7 @@ def get_openmc_universes(cells, surfaces, materials, data):
                 if use_degrees:
                     rotation_matrix = np.cos(rotation_matrix * pi/180.0)
                 print(rotation_matrix)
-                c['_region'] = c['_region'].rotate(rotation_matrix, pivot=vector)
+                c['_region'] = c['_region'].rotate(rotation_matrix.T, pivot=vector)
 
             # Update surfaces dictionary with new surfaces
             for surf_id, surf in c['_region'].get_surfaces().items():


### PR DESCRIPTION
## Problem
During my use of this adapter, I noticed that when an MCNP cell has both `fill=xxx` and `trcl=(xxx...)`, the adapter may write a wrong matrix to OpenMC geometry. Here is an example:
```
MCNP INPUT for rotation challenge
1 0       -10           IMP:N=1 *trcl=(0 0 0 45 45 90 135 45 90 90 90 0) fill=1
2 2 -1.0   1 2 -3 -4 #1 IMP:N=1
3 0       -1：-2:3:4    IMP:N=0
4 1 -10   -5            IMP:N=1 u=1
5 3 -1.1   5            IMP:N=1 u=1

1 px 0
2 py 0
3 px 20
4 py 20
5 py 0
10 sx 10 5

MODE N 
KCODE  50000 1.0 100 600
KSRC  6 7 0
M1 92235.70c  0.03
   92238.70c  0.97
M2 1001.70c  2
   8016.70c  1
M3 1002.70c  2
   8016.70c  1
```
This is a sphere in a square and the sphere is split into halves by Surf 5. MCNP's plot is 
<img src="https://github.com/openmc-dev/openmc_mcnp_adapter/assets/10403130/2b80daec-d846-47fc-b076-edf602f91ad6" width="100">

After convertion by this adapter, the plot from OpenMC is (the sphere was actually not cut by Surf 5):
<img src="https://github.com/openmc-dev/openmc_mcnp_adapter/assets/10403130/85eb78b5-2c7b-46fa-8e65-cba9ff3f2aaa" width="100">

## Solution
If we transpose the rotation matrix (what I did in this PR), then the plot will be:
<img src="https://github.com/openmc-dev/openmc_mcnp_adapter/assets/10403130/51eb9df0-c194-41c1-bd1c-59f57a918b14" width="100">

## More
I have checked cells without universe filling, and the rotation works well. But I am not familar with OpenMC's rotation, maybe double check is required.
