### PR TITLE
Macrobody facet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Some geometry features are not currently supported:
 - Periodic boundary conditions
 - `X`, `Y`, and `Z` surfaces with 1 or 3 coordinate pairs
 - `RHP`, `REC`, `TRC`, `ELL`, `WED`, and `ARB` macrobodies
-- Macrobody facets
 - Hexagonal lattices
 - One-dimensional lattices
 - Two-dimensional lattices with basis other than x-y

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -13,7 +13,8 @@ from openmc.data.ace import get_metadata
 from openmc.model.surface_composite import (
     CompositeSurface,
     RightCircularCylinder as RCC,
-    RectangularParallelepiped as RPP
+    RectangularParallelepiped as RPP,
+    OrthogonalBox as BOX,
 )
 from openmc.model import surface_composite
 
@@ -24,18 +25,26 @@ from .parse import parse, _COMPLEMENT_RE, _CELL_FILL_RE
 # attribute name and whether or not to flip the sense of that surface
 # based on the facet surface's relationship to the composite surface region
 _MACROBODY_FACETS = {
+    BOX: {
+        1: ('ax1_max', False),
+        2: ('ax1_min', False),
+        3: ('ax2_max', False),
+        4: ('ax2_min', False),
+        5: ('ax3_max', False),
+        6: ('ax3_min', False),
+    },
     RCC: {
         1: ('cyl', False),
         2: ('top', False),
         3: ('bottom', True)
     },
     RPP: {
-        1: ('xmin', True),
-        2: ('xmax', False),
-        3: ('ymin', True),
-        4: ('ymax', False),
-        5: ('zmin', True),
-        6: ('zmax', False)
+        1: ('xmax', True),
+        2: ('xmin', False),
+        3: ('ymax', True),
+        4: ('ymin', False),
+        5: ('zmax', True),
+        6: ('zmin', False)
     }
 }
 
@@ -344,9 +353,9 @@ def get_openmc_surfaces(surfaces, data):
             a2 = coeffs[6:9]
             if len(coeffs) == 12:
                 a3 = coeffs[9:]
-                surf = surface_composite.OrthogonalBox(v, a1, a2, a3)
+                surf = BOX(v, a1, a2, a3)
             else:
-                surf = surface_composite.OrthogonalBox(v, a1, a2)
+                surf = BOX(v, a1, a2)
         else:
             raise NotImplementedError('Surface type "{}" not supported'
                                       .format(s['mnemonic']))

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -303,11 +303,11 @@ def replace_macrobody_facets(region, surfaces):
         facet_loc = region.find('.')
         facet_num = int(region[facet_loc+1])
 
-        # walk back from the decimal until we hit a non-integer value:
-        start_idx = facet_loc - 1
+        # walk back from the decimal until we get a non-integer value:
+        start_idx = facet_loc
         while True:
             try:
-                int(region[start_idx])
+                int(region[start_idx - 1])
             except ValueError:
                 break
             start_idx -= 1
@@ -343,7 +343,7 @@ def replace_macrobody_facets(region, surfaces):
         surfaces[facet_surface.id] = facet_surface
 
         # re-build the region expression with this entry in place of the macrobody facet entry
-        region = region[:start_idx+1] + str(facet_id) + region[facet_loc+2:]
+        region = region[:start_idx] + str(facet_id) + region[facet_loc+2:]
 
     return region
 

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -321,15 +321,16 @@ def replace_macrobody_facets(region: str, surfaces: dict) -> str:
 
         # Get corresponding composite surface
         composite_surf = surfaces[abs(surface_id)]
-        if not isinstance(composite_surf, CompositeSurface):
-            raise TypeError(f'Macrobody facet {facet} requested for '
-                            'non-composite surface')
-
-        # Get name of attribute on composite surface and whether to flip sense
-        facet_attr, flip_sense = _MACROBODY_FACETS[type(composite_surf)][facet_num]
+        if isinstance(composite_surf, CompositeSurface):
+            # Get composite surface and whether to flip sense
+            facet_attr, flip_sense = _MACROBODY_FACETS[type(composite_surf)][facet_num]
+            facet_surface = getattr(composite_surf, facet_attr)
+        else:
+            warnings.warn(f'Macrobody facet {facet} ignored (not a macrobody)')
+            facet_surface = composite_surf
+            flip_sense = False
 
         # Get corresponding surface and its ID
-        facet_surface = getattr(composite_surf, facet_attr)
         facet_id = facet_surface.id
 
         # starting with a positive facet ID, adjust for:


### PR DESCRIPTION
I need to convert a model that uses macrobody facets for an `RCC` surface type. I've added this by parsing the macrobody facet identifier (`[sense]{macrobody}.{facet_number}`) and replacing the entry in the expression with the ID of the attribute-surface on the `openmc.SurfaceComposite` object before we send it off to `openmc.Region.from_expression`.

The sense of the surface replacing the macrobody facet in the expression is accounted for in a mapping of the facet ID to the attribute-surface based on the object. While it gets the job done I'm a little conflicted about it as most (all?) of this tool is independent of assumptions about the internals of objects in OpenMC. Still, I think any MCNP-specific conventions should be kept here. I'm open to other suggestions on how to approach this.

