### PR TITLE
Added support for non-axis-aligned RCC macrobody

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -58,7 +58,7 @@ def get_openmc_materials(materials, cells):
     Returns
     -------
     dict
-        Dictionary mapping material ID to :class:`openmc.Material`
+        Dictionary mapping MCNP material ID to dictionary using MCNP density as key and the corresponding :class:`openmc.Material` object as value.
 
     """
     materials_densities = list(itertools.groupby(sorted(cells, key=lambda cell: cell['material']), lambda c: (c['material'], c['density'])))


### PR DESCRIPTION
This PR aims to add the support for RCC macrobody with non-axis-aligned: basically a RightCircularCylinder object orientated along Z axis is created and then rotated accordingly to the MCNP definition. 
Moreover, the creation of materials and the assignment of density has been modified: currently, a material applied to cells with different densities is created each time the density is different from the "first" density value, even if a material with the same density value already exists, resulting in a very large materials.xml file. 

If I have to split the PR, please let me know.
