### PR TITLE
Add command-line option for removing redundant surfaces

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -705,10 +705,13 @@ def mcnp_to_model(filename, merge_surfaces: bool = True) -> openmc.Model:
     all_volume = openmc.Union([cell.region for cell in
                                 geometry.root_universe.cells.values()])
     ll, ur = all_volume.bounding_box
+    src_class = getattr(openmc, 'IndependentSource')
+    if src_class is None:
+        src_class = openmc.Source
     if np.any(np.isinf(ll)) or np.any(np.isinf(ur)):
-        settings.source = openmc.Source(space=openmc.stats.Point())
+        settings.source = src_class(space=openmc.stats.Point())
     else:
-        settings.source = openmc.Source(space=openmc.stats.Point((ll + ur)/2))
+        settings.source = src_class(space=openmc.stats.Point((ll + ur)/2))
 
     return openmc.Model(geometry, materials, settings)
 


### PR DESCRIPTION
This PR adds an option (enabled by default) to merge redundant surfaces before exporting to XML. It also updates to use the `IndependentSource` class from OpenMC if available.