### PR TITLE
Add support for trcl referencig a transformation

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -347,24 +347,26 @@ def get_openmc_universes(cells, surfaces, materials, data):
                 else:
                     c['parameters']['fill'] = f'{fill} {trcl}'
 
+            # Apply transformation to region
+            vector = None
+            rotation_matrix = None
+
             # check for a TRn card
             if not trcl.startswith('('):
                 vector, rotation = data['tr'][int(trcl)]
-                if rotation is not None:
-                    raise NotImplementedError(
-                        'TRn card with rotations is not supported (cell {}).'.format(c['id']))
             else:
                 # Drop parentheses
                 trcl = trcl[1:-1].split()
                 vector = tuple(float(c) for c in trcl[:3])
+                if len(trcl) > 3:
+                    rotation_matrix = np.array([float(x) for x in trcl[3:]]).reshape((3, 3))
+                    if use_degrees:
+                        rotation_matrix = np.cos(rotation_matrix * pi/180.0)
 
-            c['_region'] = c['_region'].translate(vector, translate_memo)
+            if vector is not None:
+                c['_region'] = c['_region'].translate(vector, translate_memo)
 
-            if len(trcl) > 3:
-                rotation_matrix = np.array([float(x) for x in trcl[3:]]).reshape((3, 3))
-                if use_degrees:
-                    rotation_matrix = np.cos(rotation_matrix * pi/180.0)
-                print(rotation_matrix)
+            if rotation_matrix is not None:
                 c['_region'] = c['_region'].rotate(rotation_matrix.T, pivot=vector)
 
             # Update surfaces dictionary with new surfaces

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -260,7 +260,7 @@ def get_openmc_surfaces(surfaces, data):
                 warnings.simplefilter("ignore", openmc.IDWarning)
                 surf = surf.translate(displacement, inplace=True)
                 if rotation is not None:
-                    surf = surf.rotate(rotation, pivot=displacement, inplace=True) 
+                    surf = surf.rotate(rotation, pivot=displacement, inplace=True)
 
         openmc_surfaces[s['id']] = surf
 
@@ -347,14 +347,18 @@ def get_openmc_universes(cells, surfaces, materials, data):
                 else:
                     c['parameters']['fill'] = f'{fill} {trcl}'
 
+            # check for a TRn card
             if not trcl.startswith('('):
-                raise NotImplementedError(
-                    'TRn card not supported (cell {}).'.format(c['id']))
+                displacement, rotation = data['tr'][int(trcl)]
+                if rotation is not None:
+                    raise NotImplementedError(
+                        'TRn card with rotations is not supported (cell {}).'.format(c['id']))
+                vector = displacement
+            else:
+                # Drop parentheses
+                trcl = trcl[1:-1].split()
+                vector = tuple(float(c) for c in trcl[:3])
 
-            # Drop parentheses
-            trcl = trcl[1:-1].split()
-
-            vector = tuple(float(c) for c in trcl[:3])
             c['_region'] = c['_region'].translate(vector, translate_memo)
 
             if len(trcl) > 3:
@@ -646,7 +650,7 @@ def get_openmc_universes(cells, surfaces, materials, data):
 
         elif c['material'] > 0:
             cell.fill = mat
-        
+
         if 'vol' in c["parameters"]:
             cell.volume = float(c["parameters"]["vol"])
 

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -349,11 +349,10 @@ def get_openmc_universes(cells, surfaces, materials, data):
 
             # check for a TRn card
             if not trcl.startswith('('):
-                displacement, rotation = data['tr'][int(trcl)]
+                vector, rotation = data['tr'][int(trcl)]
                 if rotation is not None:
                     raise NotImplementedError(
                         'TRn card with rotations is not supported (cell {}).'.format(c['id']))
-                vector = displacement
             else:
                 # Drop parentheses
                 trcl = trcl[1:-1].split()


### PR DESCRIPTION
As the title states, a `trcl` entry that references a `TRn` transformation. The `TRn` cards are already parsed, so I I'm understanding correctly this is just a matter of retrieving the `TRn` vector and rotation matrix and applying them as we would the `trcl` transformation.