### PR TITLE
Handle case where density and geometry specification have no separating whitespace

### DIFF
--- a/src/openmc_mcnp_adapter/parse.py
+++ b/src/openmc_mcnp_adapter/parse.py
@@ -96,6 +96,13 @@ def parse_cell(line):
             region = g[2].strip()
         else:
             words = g[2].split()
+            # MCNP allows the density and the start of the geometry
+            # specification to appear without a space inbetween if the geometry
+            # starts with '('. If this happens, move the end of the first word
+            # onto the second word to ensure the density is by itself
+            if (pos := words[0].find('(')) >= 0:
+                words[1] = words[0][pos:] + words[1]
+                words[0] = words[0][:pos]
             density = float_(words[0])
             region = ' '.join(words[1:])
         return {


### PR DESCRIPTION
MCNP evidently allows a cell card where the density and the geometry specification appear next to each other with no whitespace in between if the geometry specification begins with a left parenthesis. For example, something like:
```
100  1  -4.500( 1 -2 3 -4 )
```
Right now, this breaks the converter because the regular expression doesn't separate them. This PR puts in place a fix to check for the presence of a left parenthesis and move it and everything after it to the next "word". Not the most elegant solution but it works for now.