### PR TITLE
Store raw values from data block

### DIFF
--- a/src/openmc_mcnp_adapter/parse.py
+++ b/src/openmc_mcnp_adapter/parse.py
@@ -243,6 +243,10 @@ def parse_data(section):
             else:
                 rotation = None
             data['tr'][tr_num] = (displacement, rotation)
+        else:
+            words = line.split()
+            if words:
+                data[words[0]] = words[1:]
 
     return data
 


### PR DESCRIPTION
This PR keeps information from data cards even when it's not used. I found this useful when I wanted to pull information from SDEF and associated cards.