### PR TITLE
Write to single model.xml file by default

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -912,10 +912,17 @@ def mcnp_to_openmc():
     parser.add_argument('mcnp_filename')
     parser.add_argument('--merge-surfaces', action='store_true',
                         help='Remove redundant surfaces when exporting XML')
-    parser.add_argument('--no-merge-surfaces', dest='download', action='store_false',
+    parser.add_argument('--no-merge-surfaces', dest='merge_surfaces', action='store_false',
                         help='Do not remove redundant surfaces when exporting XML')
+    parser.add_argument('-o', '--output', default='model.xml',
+                        help='Name for the OpenMC model XML file')
+    parser.add_argument('-s', '--separate-xml', action='store_true',
+                        help='Write separate XML files')
     parser.set_defaults(merge_surfaces=True)
     args = parser.parse_args()
 
     model = mcnp_to_model(args.mcnp_filename, args.merge_surfaces)
-    model.export_to_xml()
+    if args.separate_xml:
+        model.export_to_xml()
+    else:
+        model.export_to_model_xml(args.output)


### PR DESCRIPTION
This PR changes the converter to write a model.xml file by default instead of separate XML files. There is also a new `-o` command-line argument that allows the user to specify the name of the output file.