### PR TITLE
Convert tab characters in MCNP files

### DIFF
--- a/src/openmc_mcnp_adapter/parse.py
+++ b/src/openmc_mcnp_adapter/parse.py
@@ -272,7 +272,7 @@ def split_mcnp(filename):
     return re.split('\n[ \t]*\n', text)
 
 
-def sanitize(section):
+def sanitize(section: str) -> str:
     """Sanitize one section of an MCNP input
 
     This function will remove comments, join continuation lines into a single
@@ -289,6 +289,9 @@ def sanitize(section):
         Sanitized input section
 
     """
+
+    # Replace tab characters
+    section = section.expandtabs()
 
     # Remove end-of-line comments
     section = re.sub(r'\$.*$', '', section, flags=re.MULTILINE)


### PR DESCRIPTION
I ran into a model that has tab characters and apparently this is allowed by MCNP. The manual has this to say about tab characters:
>  Tab characters in the input file are converted to one or more blank spaces, such that the character following the tab will be positioned at the next tab stop. Tab stops are set every eight characters, i.e., 9, 17, 25, etc. The limit of input lines to 128 columns applies after tabs are expanded into blank spaces. It is recommended that blank spaces be used instead of tab characters for this reason.

Thankfully this can be treated easily using the [`str.expandtabs`](https://docs.python.org/3/library/stdtypes.html#str.expandtabs) method, which defaults to exactly the behavior described above (kudos to @MicahGale for pointing this out).