### PR TITLE
Allow whitespace within cell complement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 UChicago Argonne, LLC
+Copyright (c) 2022-2025 UChicago Argonne, LLC and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/openmc_mcnp_adapter/__init__.py
+++ b/src/openmc_mcnp_adapter/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: 2022-2024 UChicago Argonne, LLC and contributors
+# SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC and contributors
 # SPDX-License-Identifier: MIT

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 UChicago Argonne, LLC and contributors
+# SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC and contributors
 # SPDX-License-Identifier: MIT
 
 import argparse

--- a/src/openmc_mcnp_adapter/parse.py
+++ b/src/openmc_mcnp_adapter/parse.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2024 UChicago Argonne, LLC and contributors
+# SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC and contributors
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict
@@ -13,6 +13,7 @@ _KEYWORDS = [
     r'\*?trcl', r'\*?fill', 'tmp', 'u', 'lat',
     'imp:.', 'vol', 'pwt', 'ext:.', 'fcl', 'wwn', 'dxc', 'nonu', 'pd',
     'elpt', 'cosy', 'bflcl', 'unc',
+    'pmt'  # D1SUNED-specific
 ]
 _ANY_KEYWORD = '|'.join(f'(?:{k})' for k in _KEYWORDS)
 _CELL_PARAMETERS_RE = re.compile(rf"""
@@ -31,7 +32,7 @@ _MATERIAL_RE = re.compile(r'\s*[Mm](\d+)((?:\s+\S+)+)')
 _TR_RE = re.compile(r'\s*(\*)?[Tt][Rr](\d+)\s+(.*)')
 _SAB_RE = re.compile(r'\s*[Mm][Tt](\d+)((?:\s+\S+)+)')
 _MODE_RE = re.compile(r'\s*mode(?:\s+\S+)*')
-_COMPLEMENT_RE = re.compile(r'(#)(\d+)')
+_COMPLEMENT_RE = re.compile(r'(#)[ ]*(\d+)')
 _REPEAT_RE = re.compile(r'(\d+)\s+(\d+)[rR]')
 _NUM_RE = re.compile(r'(\d)([+-])(\d)')
 


### PR DESCRIPTION
When a cell complement is specified in a cell geometry specification, e.g. "#5" meaning the complement of cell 5, whitespace is allowed to appear between the "#" and the number following. This fixes the regular expression we use to check for cell complements to allow whitespace.

A few unrelated updates in here as well:
- Account for the D1SUNED-specific "PMT" cell keyword
- Update copyrights to 2025