### PR TITLE
Improve handling of materials with same composition but different density

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Run tests
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    container: openmc/openmc:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apt dependencies
+        shell: bash
+        run: |
+          apt -y update
+          apt install -y python3-venv
+          python -m venv venv
+          source venv/bin/activate
+
+      - name: Install
+        shell: bash
+        run: |
+          pip install -U pip
+          pushd /root/OpenMC/openmc
+          pip install .[test]
+          popd
+          pip install .[test]
+
+      - name: Test
+        shell: bash
+        run: pytest -rs tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,14 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Physics",
 ]
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/openmc-dev/openmc_mcnp_adapter/issues"

--- a/src/openmc_mcnp_adapter/__init__.py
+++ b/src/openmc_mcnp_adapter/__init__.py
@@ -1,2 +1,5 @@
 # SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC and contributors
 # SPDX-License-Identifier: MIT
+
+from .openmc_conversion import *  # noqa: F403
+from .parse import *  # noqa: F403

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -3,6 +3,7 @@
 
 import argparse
 from math import pi
+import os
 import re
 import tempfile
 import warnings
@@ -912,10 +913,16 @@ def mcnp_to_model(filename, merge_surfaces: bool = True) -> openmc.Model:
 
 
 def mcnp_str_to_model(text: str, merge_surfaces: bool = True):
-    with tempfile.NamedTemporaryFile('w', delete_on_close=False) as fp:
+    # Write string to a temporary file
+    with tempfile.NamedTemporaryFile('w', delete=False) as fp:
         fp.write(text)
-        fp.close()
-        return mcnp_to_model(fp.name, merge_surfaces)
+
+    # Parse model from file
+    model = mcnp_to_model(fp.name, merge_surfaces)
+
+    # Remove temporary file and return model
+    os.remove(fp.name)
+    return model
 
 
 def mcnp_to_openmc():

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -4,6 +4,7 @@
 import argparse
 from math import pi
 import re
+import tempfile
 import warnings
 
 import numpy as np
@@ -639,22 +640,25 @@ def get_openmc_universes(cells, surfaces, materials, data):
 
         # Determine material fill if present -- this is not assigned until later
         # in case it's used in a lattice (need to create an extra universe then)
-        if c['material'] > 0:
-            mat = materials[c['material']]
+        cell_material_id: int = c['material']
+        if cell_material_id > 0:
+            mat = materials[cell_material_id]
+            cell_density = c['density']
             if mat.density is None:
-                if c['density'] > 0:
-                    mat.set_density('atom/b-cm', c['density'])
+                if cell_density > 0:
+                    mat.set_density('atom/b-cm', cell_density)
                 else:
-                    mat.set_density('g/cm3', abs(c['density']))
-            else:
-                if mat.density != abs(c['density']):
-                    key = (c['material'], c['density'])
-                    if key not in material_clones:
-                        material_clones[key] = mat = mat.clone()
-                        if c['density'] > 0:
-                            mat.set_density('atom/b-cm', c['density'])
-                        else:
-                            mat.set_density('g/cm3', abs(c['density']))
+                    mat.set_density('g/cm3', abs(cell_density))
+            elif mat.density != abs(c['density']):
+                key = (cell_material_id, cell_density)
+                if key not in material_clones:
+                    material_clones[key] = mat = mat.clone()
+                    if c['density'] > 0:
+                        mat.set_density('atom/b-cm', c['density'])
+                    else:
+                        mat.set_density('g/cm3', abs(c['density']))
+                else:
+                    mat = material_clones[key]
 
         # Create lattices
         if 'fill' in c['parameters'] or '*fill' in c['parameters']:
@@ -905,6 +909,13 @@ def mcnp_to_model(filename, merge_surfaces: bool = True) -> openmc.Model:
         settings.source = src_class(space=openmc.stats.Point((ll + ur)/2))
 
     return openmc.Model(geometry, materials, settings)
+
+
+def mcnp_str_to_model(text: str, merge_surfaces: bool = True):
+    with tempfile.NamedTemporaryFile('w', delete_on_close=False) as fp:
+        fp.write(text)
+        fp.close()
+        return mcnp_to_model(fp.name, merge_surfaces)
 
 
 def mcnp_to_openmc():

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -604,6 +604,7 @@ def get_openmc_universes(cells, surfaces, materials, data):
 
     # Now that all cell regions have been converted, the next loop is to create
     # actual Cell/Universe/Lattice objects
+    material_clones = {}
     for c in cells:
         cell = openmc.Cell(cell_id=c['id'])
 
@@ -647,13 +648,13 @@ def get_openmc_universes(cells, surfaces, materials, data):
                     mat.set_density('g/cm3', abs(c['density']))
             else:
                 if mat.density != abs(c['density']):
-                    print("WARNING: Cell {} has same material but with a "
-                          "different density than that of another.".format(c['id']))
-                    mat = mat.clone()
-                    if c['density'] > 0:
-                        mat.set_density('atom/b-cm', c['density'])
-                    else:
-                        mat.set_density('g/cm3', abs(c['density']))
+                    key = (c['material'], c['density'])
+                    if key not in material_clones:
+                        material_clones[key] = mat = mat.clone()
+                        if c['density'] > 0:
+                            mat.set_density('atom/b-cm', c['density'])
+                        else:
+                            mat.set_density('g/cm3', abs(c['density']))
 
         # Create lattices
         if 'fill' in c['parameters'] or '*fill' in c['parameters']:

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,0 +1,26 @@
+import textwrap
+
+from openmc_mcnp_adapter import mcnp_str_to_model
+from pytest import approx
+
+
+def test_material_clones():
+    mcnp_model = textwrap.dedent("""
+        title
+        1   1 -1.0    1 -2
+        2   1 -2.0    1  2
+        3   1 -2.0   -1 -2
+        4   1 -1.0   -1  2
+
+        1   px 0.0
+        2   py 1.0
+
+        m1   1001.80c  3.0
+    """)
+
+    model = mcnp_str_to_model(mcnp_model)
+    cells = model.geometry.get_all_cells()
+    assert cells[1].fill.id == cells[4].fill.id == 1
+    assert cells[2].fill.id == cells[3].fill.id != 1
+    assert cells[1].fill.get_mass_density() == approx(1.0)
+    assert cells[2].fill.get_mass_density() == approx(2.0)


### PR DESCRIPTION
Right now when two cells are filled with the same material but specify different densities, we clone the material whenever the density doesn't match the first listed density. This means that if you have material 1 listed with a density of 1 g/cm3 in one cell and then material 1 listed with a density of 2 g/cm3 in 10 cells, you end up with 10 extra copies even though you really only need a single copy. This PR fixes that behavior so that a copy is only created for each unique density.

This was originally identified @giemme90 in #8.

Notably, this PR also contains the first test that can be expanded on in the future.