### PR TITLE
Improve check for zero-importance cell for vacuum boundary

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -628,13 +628,13 @@ def get_openmc_universes(cells, surfaces, materials, data):
         # Look for vacuum boundary condition
         if isinstance(cell.region, openmc.Union):
             if all([isinstance(n, openmc.Halfspace) for n in cell.region]):
-                if 'imp:n' in c['parameters'] and c['parameters']['imp:n'] == '0':
+                if 'imp:n' in c['parameters'] and float(c['parameters']['imp:n']) == 0.0:
                     for n in cell.region:
                         if n.surface.boundary_type == 'transmission':
                             n.surface.boundary_type = 'vacuum'
                     root_universe.remove_cell(cell)
         elif isinstance(cell.region, openmc.Halfspace):
-            if 'imp:n' in c['parameters'] and c['parameters']['imp:n'] == '0':
+            if 'imp:n' in c['parameters'] and float(c['parameters']['imp:n']) == 0.0:
                 if cell.region.surface.boundary_type == 'transmission':
                     cell.region.surface.boundary_type = 'vacuum'
                 root_universe.remove_cell(cell)

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,0 +1,53 @@
+import textwrap
+
+from openmc_mcnp_adapter import mcnp_str_to_model
+
+
+def test_vacuum_sphere():
+    mcnp_model = textwrap.dedent("""
+        title
+        1   1 -1.0    -1 imp:n=1
+        2   0          1 imp:n=0
+
+        1   so 30.0
+
+        m1   1001.80c  3.0
+    """)
+
+    model = mcnp_str_to_model(mcnp_model)
+    surf = model.geometry.get_all_surfaces()[1]
+    assert surf.boundary_type == 'vacuum'
+
+
+def test_vacuum_cylinder():
+    mcnp_model = textwrap.dedent("""
+        title
+        1   1 -1.0    -1 2 -3  imp:n=1.0
+        2   0          1:-2:3  imp:n=0.0
+
+        1   cz  1.0
+        2   pz -1.0
+        3   pz  1.0
+
+        m1   1001.80c  3.0
+    """)
+
+    model = mcnp_str_to_model(mcnp_model)
+    for surf in model.geometry.get_all_surfaces().values():
+        assert surf.boundary_type == 'vacuum'
+
+
+def test_vacuum_box():
+    mcnp_model = textwrap.dedent("""
+        title
+        1   1 -1.0    -1  imp:n=1.00
+        2   0          1  imp:n=0.00
+
+        1   rpp -1 1 -1 1 -1 1
+
+        m1   1001.80c  3.0
+    """)
+
+    model = mcnp_str_to_model(mcnp_model)
+    for surf in model.geometry.get_all_surfaces().values():
+        assert surf.boundary_type == 'vacuum'


### PR DESCRIPTION
To determine a vacuum boundary, the converter looks for a zero-importance cell. Right now it looks for `imp:n=0` but it doesn't work if `imp:n=0.0`. This PR changes it so that it checks if the value converted to a float is equal to zero to handle both cases.