### PR TITLE
Option to not expand elements to their constituent isotopes

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -104,7 +104,7 @@ def rotation_matrix(v1, v2):
         return I + K * sin_angle + (K @ K) * (1 - cos_angle)
 
 
-def get_openmc_materials(materials):
+def get_openmc_materials(materials, expand_elements: bool = True):
     """Get OpenMC materials from MCNP materials
 
     Parameters
@@ -130,12 +130,12 @@ def get_openmc_materials(materials):
                 zaid = nuclide
             name, element, Z, A, metastable = get_metadata(int(zaid), 'mcnp')
             if percent < 0:
-                if A > 0:
+                if (A > 0) or (not expand_elements):
                     material.add_nuclide(name, abs(percent), 'wo')
                 else:
                     material.add_element(element, abs(percent), 'wo')
             else:
-                if A > 0:
+                if (A > 0) or (not expand_elements):
                     material.add_nuclide(name, percent, 'ao')
                 else:
                     material.add_element(element, percent, 'ao')
@@ -863,7 +863,7 @@ def get_openmc_universes(cells, surfaces, materials, data):
     return universes
 
 
-def mcnp_to_model(filename, merge_surfaces: bool = True) -> openmc.Model:
+def mcnp_to_model(filename, merge_surfaces: bool = True, expand_elements: bool = True) -> openmc.Model:
     """Convert MCNP input to OpenMC model
 
     Parameters
@@ -882,7 +882,7 @@ def mcnp_to_model(filename, merge_surfaces: bool = True) -> openmc.Model:
 
     cells, surfaces, data = parse(filename)
 
-    openmc_materials = get_openmc_materials(data['materials'])
+    openmc_materials = get_openmc_materials(data['materials'], expand_elements)
     openmc_surfaces = get_openmc_surfaces(surfaces, data)
     openmc_universes = get_openmc_universes(cells, openmc_surfaces,
                                             openmc_materials, data)
@@ -933,14 +933,19 @@ def mcnp_to_openmc():
                         help='Remove redundant surfaces when exporting XML')
     parser.add_argument('--no-merge-surfaces', dest='merge_surfaces', action='store_false',
                         help='Do not remove redundant surfaces when exporting XML')
+    parser.add_argument('--expand-elements', action='store_true',
+                        help='Expand elements to their constituent isotopes')
+    parser.add_argument('--no-expand-elements', dest='expand_elements', action='store_false',
+                        help='Do not expand elements to their constituent isotopes')
     parser.add_argument('-o', '--output', default='model.xml',
                         help='Name for the OpenMC model XML file')
     parser.add_argument('-s', '--separate-xml', action='store_true',
                         help='Write separate XML files')
     parser.set_defaults(merge_surfaces=True)
+    parser.set_defaults(expand_elements=True)
     args = parser.parse_args()
 
-    model = mcnp_to_model(args.mcnp_filename, args.merge_surfaces)
+    model = mcnp_to_model(args.mcnp_filename, args.merge_surfaces, args.expand_elements)
     if args.separate_xml:
         model.export_to_xml()
     else:


### PR DESCRIPTION
By default, the converter employs the `openmc.Element.expand` method to decompose the natural isotopes, i.e. those having the atomic mass number equal to `0`.
This behavior lets the materials generated for OpenMC does not match the corresponding ones defined in the MCNP input deck.

It is worth mentioning that the natural isotopic abundances may be defined according to different sources, e.g. [NIST](https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses) or [IUPAC](https://doi.org/10.1515/pac-2015-0503), or selecting either the center of the range provided or the best measurement.
Indeed, depending on the desired nuclear data libraries and the isotopes defined therein, the analyst may wish to keep the original isotope definition as in the MCNP input deck.

This branch provides an additional command-line switch that allows the user to unselect the automatic expansion of natural elements according to the abundances encoded in the OpenMC sources so that the materials defined are 1:1 with respect to the definitions available in the MCNP input deck.