### PR TITLE
Fix RPP macrobody facets

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -326,6 +326,9 @@ def get_openmc_surfaces(surfaces, data):
             
             # Track if height vector is negative (for facet mapping later)
             height_was_negative = False
+            # Check if cumulative components of height are making it point backwards
+            if (hx+hy+hz) < 0:  
+                height_was_negative = True
             
             if hx == 0.0 and hy == 0.0:
                 if hz < 0.0:
@@ -349,14 +352,7 @@ def get_openmc_surfaces(surfaces, data):
                 # Create vectors for Z-axis and cylinder orientation
                 u = np.array([0., 0., 1.])
                 h = np.array([hx, hy, hz])
-                
-                # Check if any component of height is making it point backwards
-                # This is more complex for arbitrary orientations
-                height_magnitude = np.linalg.norm(h)
-                if height_magnitude < 0:  # This won't happen with norm
-                    height_was_negative = True
-                # For arbitrary orientation, we'd need more logic here
-        
+
                 # Determine rotation matrix to transform u -> h
                 rotation = rotation_matrix(u, h)
         
@@ -367,8 +363,7 @@ def get_openmc_surfaces(surfaces, data):
                 # Rotate the RCC
                 surf = surf.rotate(rotation, pivot=(vx, vy, vz))
             
-            # Store whether height was negative as an attribute
-            # This will be used in replace_macrobody_facets
+            # Store whether height was negative as an attribute, this will be used in replace_macrobody_facets
             surf._mcnp_negative_height = height_was_negative
 
         elif s['mnemonic'] == 'rpp':

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -332,19 +332,16 @@ def get_openmc_surfaces(surfaces, data):
             
             if hx == 0.0 and hy == 0.0:
                 if hz < 0.0:
-                    height_was_negative = True
                     vz += hz
                     hz = -hz
                 surf = RCC((vx, vy, vz), hz, r, axis='z')
             elif hy == 0.0 and hz == 0.0:
                 if hx < 0.0:
-                    height_was_negative = True
                     vx += hx
                     hx = -hx
                 surf = RCC((vx, vy, vz), hx, r, axis='x')
             elif hx == 0.0 and hz == 0.0:
                 if hy < 0.0:
-                    height_was_negative = True
                     vy += hy
                     hy = -hy
                 surf = RCC((vx, vy, vz), hy, r, axis='y')

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -43,11 +43,11 @@ _MACROBODY_FACETS = {
     },
     RPP: {
         1: ('xmax', False),
-        2: ('xmin', False),
+        2: ('xmin', True),
         3: ('ymax', False),
-        4: ('ymin', False),
+        4: ('ymin', True),
         5: ('zmax', False),
-        6: ('zmin', False)
+        6: ('zmin', True)
     },
     TRC: {
         1: ('cone', False),

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -42,11 +42,11 @@ _MACROBODY_FACETS = {
         3: ('bottom', True)
     },
     RPP: {
-        1: ('xmax', True),
+        1: ('xmax', False),
         2: ('xmin', False),
-        3: ('ymax', True),
+        3: ('ymax', False),
         4: ('ymin', False),
-        5: ('zmax', True),
+        5: ('zmax', False),
         6: ('zmin', False)
     },
     TRC: {

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -326,13 +326,6 @@ def get_openmc_surfaces(surfaces, data):
                 raise NotImplementedError(f"{s['mnemonic']} surface with {len(coeffs)} parameters")
         elif s['mnemonic'] == 'rcc':
             vx, vy, vz, hx, hy, hz, r = coeffs
-            
-            # Track if height vector is negative (for facet mapping later)
-            height_was_negative = False
-            # Check if cumulative components of height are making it point backwards
-            if (hx+hy+hz) < 0:  
-                height_was_negative = True
-            
             if hx == 0.0 and hy == 0.0:
                 if hz < 0.0:
                     vz += hz
@@ -355,16 +348,13 @@ def get_openmc_surfaces(surfaces, data):
 
                 # Determine rotation matrix to transform u -> h
                 rotation = rotation_matrix(u, h)
-        
+
                 # Create RCC aligned with Z-axis
                 height = np.linalg.norm(h)
                 surf = RCC((vx, vy, vz), height, r, axis='z')
-        
+
                 # Rotate the RCC
                 surf = surf.rotate(rotation, pivot=(vx, vy, vz))
-            
-            # Store whether height was negative as an attribute, this will be used in replace_macrobody_facets
-            surf._mcnp_negative_height = height_was_negative
 
         elif s['mnemonic'] == 'rpp':
             surf = RPP(*coeffs)
@@ -437,19 +427,10 @@ def replace_macrobody_facets(region: str, surfaces: dict) -> str:
 
         # Get corresponding composite surface
         composite_surf = surfaces[abs(surface_id)]
-        
         if isinstance(composite_surf, CompositeSurface):
-            # Special handling for RCC facets that had negative height in MCNP
-            if isinstance(composite_surf, RCC) and facet_num in [2, 3]:
-                # Check if this RCC was created from negative height
-                if hasattr(composite_surf, '_mcnp_negative_height') and composite_surf._mcnp_negative_height:
-                    # Swap facets 2 and 3
-                    facet_num = 5 - facet_num
-            
             # Get composite surface and whether to flip sense
             facet_attr, flip_sense = _MACROBODY_FACETS[type(composite_surf)][facet_num]
             facet_surface = getattr(composite_surf, facet_attr)
-                
         else:
             warnings.warn(f'Macrobody facet {facet} ignored (not a macrobody)')
             facet_surface = composite_surf

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -271,7 +271,6 @@ def test_trc_macrobody():
     assert (0., 0., 10.01) in +surf
 
 
-@pytest.mark.xfail(reason="RPP facets currently broken", strict=False)
 def test_rpp_facets():
     mcnp_str = dedent("""
     title


### PR DESCRIPTION
This PR seeks to resolve issues, https://github.com/openmc-dev/openmc_mcnp_adapter/issues/37, <s>https://github.com/openmc-dev/openmc_mcnp_adapter/issues/38</s>

#37, resolved by changing flip_sense for RPP facets all to false. A bit surprising to me, but I guess the way it considers them is already correct?

<s>#38 , resolved by detection of RCCs with negative height. This was messing up the selection of the correct facet and sense. The detection of negative height than informs replace_macrobody_facets method.

The latter probably occurs with other macrobodies when they too are defined in, particular ways. And this is a RCC specific fix-up, not generalized.</s>


I have tested this on the example inputs for issues 37, 38, as well as on an original much larger model and another macrobody heavy model.
The fixes work in these cases and the larger model and macrobody conversion is not broken.

I have not systematically tested this on a large variety of inputs (which would be best).

I used quite a bit of Claude Opus 4.1 to implement the detection and flipping. Though I have steered it quite a bit and tested the implementation myself manually. But probably some greater scrutiny is called for.