### PR TITLE
Support two-parameter `X`, `Y`, and `Z` surfaces

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -302,7 +302,10 @@ def get_openmc_surfaces(surfaces, data):
             cls_plane = getattr(openmc, f'{axis}Plane')
             cls_cylinder = getattr(openmc, f'{axis}Cylinder')
             cls_cone = getattr(surface_composite, f'{axis}ConeOneSided')
-            if len(coeffs) == 4:
+            if len(coeffs) == 2:
+                x1, r1 = coeffs
+                surf = cls_plane(x1, surface_id=s['id'])
+            elif len(coeffs) == 4:
                 x1, r1, x2, r2 = coeffs
                 if x1 == x2:
                     surf = cls_plane(x1, surface_id=s['id'])

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -1,7 +1,10 @@
 from collections.abc import Sequence
 
 import openmc
-from openmc_mcnp_adapter import mcnp_str_to_model
+from openmc.model.surface_composite import OrthogonalBox, \
+    RectangularParallelepiped, RightCircularCylinder, ConicalFrustum
+from openmc_mcnp_adapter import get_openmc_surfaces
+import pytest
 from pytest import approx, mark
 
 
@@ -20,10 +23,9 @@ def convert_surface(mnemonic: str, params: Sequence[float]) -> openmc.Surface:
     Converted surface
 
     """
-    surf_card = "1  " + mnemonic + " " + " ".join(str(x) for x in params)
-    mcnp_str = f"title\n1  1 -1.0  -1\n\n{surf_card}\n\nm1   1001.80c  3.0"
-    model = mcnp_str_to_model(mcnp_str)
-    return model.geometry.get_all_surfaces()[1]
+    surface = {'id': 1, 'mnemonic': mnemonic, 'coefficients': params, 'reflective': False}
+    surfaces = get_openmc_surfaces([surface], {})
+    return surfaces[1]
 
 
 @mark.parametrize(
@@ -40,6 +42,19 @@ def test_planes(mnemonic, params, expected_type, attrs):
     assert isinstance(surf, expected_type)
     for attr, value in zip(attrs, params):
         assert getattr(surf, attr) == approx(value)
+
+
+def test_plane_from_points():
+    # Points defining plane y = x - 1
+    coeffs = (1.0, 0.0, 0.0,
+              2.0, 1.0, 0.0,
+              1.0, 0.0, 1.0)
+    surf = convert_surface("p", coeffs)
+    assert isinstance(surf, openmc.Plane)
+    assert surf.a == approx(1.0)
+    assert surf.b == approx(-1.0)
+    assert surf.c == approx(0.0)
+    assert surf.d == approx(1.0)
 
 
 @mark.parametrize(
@@ -129,7 +144,19 @@ def test_cones_two_sided(mnemonic, params, expected_type, attrs):
         assert surf.y0 == 0.0
 
 
-# TODO: SQ
+def test_ellipsoid_sq():
+    coeffs = (1.0, 2.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.2, 0.0, 0.0)
+    surf = convert_surface("sq", coeffs)
+    a, b, c, d, e, f, g, x, y, z = coeffs
+    assert isinstance(surf, openmc.Quadric)
+    assert surf.a == approx(a)
+    assert surf.b == approx(b)
+    assert surf.c == approx(c)
+    assert surf.d == surf.e == surf.f == 0.0
+    assert surf.g == approx(2*(d - a*x))
+    assert surf.h == approx(2*(e - b*y))
+    assert surf.j == approx(2*(f - c*z))
+    assert surf.k == approx(a*x*x + b*y*y + c*z*z + 2*(d*x + e*y + f*z) + g)
 
 
 def test_general_quadric_gq():
@@ -161,24 +188,87 @@ def test_torus(mnemonic, expected_type):
         assert getattr(surf, name) == approx(val)
 
 
-# TODO: X, Y, Z, and P
+@mark.parametrize(
+    "mnemonic, params, expected_type, attr, value",
+    [
+        ("x", (-4.0, 3.0), openmc.XPlane, "x0", -4.0),
+        ("x", (1.0, 2.0, 1.0, 3.0), openmc.XPlane, "x0", 1.0),
+        ("x", (0.0, 1.0, 5.0, 1.0), openmc.XCylinder, "r", 1.0),
+        ("y", (6.0, 2.0), openmc.YPlane, "y0", 6.0),
+        ("y", (2.5, 3.0, 2.5, 6.0), openmc.YPlane, "y0", 2.5),
+        ("y", (0.0, 0.8, -4.0, 0.8), openmc.YCylinder, "r", 0.8),
+        ("z", (0.0, 1.0), openmc.ZPlane, "z0", 0.0),
+        ("z", (-3.0, 4.4, -3.0, 7.7), openmc.ZPlane, "z0", -3.0),
+        ("z", (0.0, 2.2, 9.0, 2.2), openmc.ZCylinder, "r", 2.2),
+    ],
+)
+def test_axisymmetric_surfaces(mnemonic, params, expected_type, attr, value):
+    """Test conversion of X/Y/Z surfaces"""
+    surf = convert_surface(mnemonic, params)
+    assert isinstance(surf, expected_type)
+    assert getattr(surf, attr) == approx(value)
 
-# TODO: General plane defined by three points (P)
 
-# TODO: BOX
+def test_box_macrobody():
+    coeffs = (0.0, 0.0, 0.0,
+              1.0, 0.0, 0.0,
+              0.0, 2.0, 0.0,
+              0.0, 0.0, 3.0)
+    surf = convert_surface("box", coeffs)
+    assert isinstance(surf, OrthogonalBox)
+    # Plane position along an axis is d / coefficient
+    assert surf.ax1_min.d / surf.ax1_min.a == approx(0.0)
+    assert surf.ax1_max.d / surf.ax1_max.a == approx(1.0)
+    assert surf.ax2_min.d / surf.ax2_min.b == approx(0.0)
+    assert surf.ax2_max.d / surf.ax2_max.b == approx(2.0)
+    assert surf.ax3_min.d / surf.ax3_min.c == approx(0.0)
+    assert surf.ax3_max.d / surf.ax3_max.c == approx(3.0)
 
-# TODO: RPP
 
-# TODO: RCC
+def test_rpp_macrobody():
+    coeffs = (-1.0, 2.0, -3.0, 4.0, 0.5, 5.5)
+    surf = convert_surface("rpp", coeffs)
+    assert isinstance(surf, RectangularParallelepiped)
+    assert surf.xmin.d / surf.xmin.a == approx(-1.0)
+    assert surf.xmax.d / surf.xmax.a == approx(2.0)
+    assert surf.ymin.d / surf.ymin.b == approx(-3.0)
+    assert surf.ymax.d / surf.ymax.b == approx(4.0)
+    assert surf.zmin.d / surf.zmin.c == approx(0.5)
+    assert surf.zmax.d / surf.zmax.c == approx(5.5)
 
-# TODO: RHP, HEX
 
-# TODO: REC
+@mark.parametrize(
+    "coeffs, expected_bottom_z, expected_top_z, r",
+    [
+        # Base at (0,0,0), height +5 along z
+        ((0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 1.5), 0.0, 5.0, 1.5),
+        # Negative height vector should be flipped internally (known failing behavior)
+        pytest.param((0.0, 0.0, 0.0, 0.0, 0.0, -5.0, 1.0), 0.0, -5.0, 1.0,
+                     marks=pytest.mark.xfail(reason="Negative height handling not implemented", strict=False)),
+    ],
+)
+def test_rcc_macrobody(coeffs, expected_bottom_z, expected_top_z, r):
+    surf = convert_surface("rcc", coeffs)
+    assert isinstance(surf, RightCircularCylinder)
+    assert surf.cyl.r == approx(r)
+    assert surf.bottom.d / surf.bottom.c == approx(expected_bottom_z)
+    assert surf.top.d / surf.top.c == approx(expected_top_z)
 
-# TODO: TRC
 
-# TODO: ELL
+def test_trc_macrobody():
+    coeffs = (0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 1.0, 2.0)
+    surf = convert_surface("trc", coeffs)
+    assert isinstance(surf, ConicalFrustum)
+    assert surf.plane_bottom.d / surf.plane_bottom.c == approx(0.0)
+    assert surf.plane_top.d / surf.plane_top.c == approx(10.0)
+    # Check points near boundary
+    assert (0.99, 0., 0.01) in -surf
+    assert (1.01, 0., 0.01) in +surf
+    assert (1.99, 0., 9.99) in -surf
+    assert (2.01, 0., 9.99) in +surf
+    assert (0., 0., -0.01) in +surf
+    assert (0., 0., 10.01) in +surf
 
-# TODO: WED
 
-# TODO: ARB
+# Remaining macrobody / complex surfaces not yet implemented in conversion:
+# RHP, HEX, REC, ELL, WED, ARB


### PR DESCRIPTION
This PR adds support for the two-parameter versions of `X`, `Y`, and `Z` surfaces. I've also added a bunch of new tests as well as two expected failures for macrobody facets (should be resolved by other PRs)