### PR TITLE
Add a few more tests

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -262,14 +262,14 @@ def get_openmc_surfaces(surfaces, data):
                     surf = surface_composite.XConeOneSided(x0=x0, y0=y0, z0=z0, r2=R2, up=up)
                 elif s['mnemonic'] == 'k/y':
                     surf = surface_composite.YConeOneSided(x0=x0, y0=y0, z0=z0, r2=R2, up=up)
-                elif s['mnemonic'] == 'k/z':
+                else:
                     surf = surface_composite.ZConeOneSided(x0=x0, y0=y0, z0=z0, r2=R2, up=up)
             else:
                 if s['mnemonic'] == 'k/x':
                     surf = openmc.XCone(surface_id=s['id'], x0=x0, y0=y0, z0=z0, r2=R2)
                 elif s['mnemonic'] == 'k/y':
                     surf = openmc.YCone(surface_id=s['id'], x0=x0, y0=y0, z0=z0, r2=R2)
-                elif s['mnemonic'] == 'k/z':
+                else:
                     surf = openmc.ZCone(surface_id=s['id'], x0=x0, y0=y0, z0=z0, r2=R2)
         elif s['mnemonic'] in ('kx', 'ky', 'kz'):
             x, R2 = coeffs[:2]
@@ -279,14 +279,14 @@ def get_openmc_surfaces(surfaces, data):
                     surf = surface_composite.XConeOneSided(x0=x, r2=R2, up=up)
                 elif s['mnemonic'] == 'ky':
                     surf = surface_composite.YConeOneSided(y0=x, r2=R2, up=up)
-                elif s['mnemonic'] == 'kz':
+                else:
                     surf = surface_composite.ZConeOneSided(z0=x, r2=R2, up=up)
             else:
                 if s['mnemonic'] == 'kx':
                     surf = openmc.XCone(surface_id=s['id'], x0=x, r2=R2)
                 elif s['mnemonic'] == 'ky':
                     surf = openmc.YCone(surface_id=s['id'], y0=x, r2=R2)
-                elif s['mnemonic'] == 'kz':
+                else:
                     surf = openmc.ZCone(surface_id=s['id'], z0=x, r2=R2)
         elif s['mnemonic'] == 'sq':
             a, b, c, D, E, F, G, x, y, z = coeffs

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -135,6 +135,21 @@ def test_trcl(cell_card, surface_cards, points_inside, points_outside):
         assert point not in cell.region
 
 
+def test_trcl_macrobody():
+    mcnp_str = dedent("""
+    title
+    1 0 -1 trcl=(2.0 0.0 0.0)
+
+    1 rpp -1.0 1.0 -1.0 1.0 -1.0 1.0
+
+    m1     1001.80c  1.0
+    """)
+    model = mcnp_str_to_model(mcnp_str)
+    cell = model.geometry.get_all_cells()[1]
+    assert (1.5, 0., 0.) in cell.region
+    assert (0., 0., 0.) not in cell.region
+
+
 @mark.parametrize(
     "keywords",
     [
@@ -170,3 +185,17 @@ def test_fill_transformation(keywords):
     assert geometry.find((2.0, 0.0, 0.0))[-1] is cells[2]
     assert geometry.find((4.0, 0.0, 0.0))[-1] is cells[3]
     assert geometry.find((0.0, 0.0, 0.0))[-1] is cells[3]
+
+
+def test_cell_volume():
+    mcnp_str = dedent("""
+    title
+    1 0 -1  VOL=5.0
+
+    1 so 1.0
+
+    m1   1001.80c  1.0
+    """)
+    model = mcnp_str_to_model(mcnp_str)
+    cell = model.geometry.get_all_cells()[1]
+    assert cell.volume == 5.0


### PR DESCRIPTION
This PR adds a few more tests:

- TRCL on a cell whose definition includes a macrobody
- VOL keyword on a cell
- Invalid plane when using `P` surface
- `BOX` macrobody with 9 parameters (infinite in one direction)