### PR TITLE
Added openmc as a dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.10"
 
 dependencies = [
   "numpy",
+  "openmc>=0.15"
 ]
 
 classifiers = [
@@ -29,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Physics",
 ]
 


### PR DESCRIPTION
This is a quick change in `pyproject.toml` to specify that `openmc` is a dependency. This could cause issues with `pip` if users don't already have `openmc` installed prior to `pip install`ing this. However, the same can be said about running this utility. 

Fixes #57. 