### PR TITLE
Convert degenerate torus (A=0, B=C) to sphere 

### DIFF
--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -301,15 +301,13 @@ def get_openmc_surfaces(surfaces, data):
             a, b, c, d, e, f, g, h, j, k = coeffs
             surf = openmc.Quadric(surface_id=s['id'], a=a, b=b, c=c, d=d, e=e,
                                   f=f, g=g, h=h, j=j, k=k)
-        elif s['mnemonic'] == 'tx':
+        elif s['mnemonic'] in ('tx', 'ty', 'tz'):
             x0, y0, z0, a, b, c = coeffs
-            surf = openmc.XTorus(surface_id=s['id'], x0=x0, y0=y0, z0=z0, a=a, b=b, c=c)
-        elif s['mnemonic'] == 'ty':
-            x0, y0, z0, a, b, c = coeffs
-            surf = openmc.YTorus(surface_id=s['id'], x0=x0, y0=y0, z0=z0, a=a, b=b, c=c)
-        elif s['mnemonic'] == 'tz':
-            x0, y0, z0, a, b, c = coeffs
-            surf = openmc.ZTorus(surface_id=s['id'], x0=x0, y0=y0, z0=z0, a=a, b=b, c=c)
+            if a == 0 and b == c:
+                surf = openmc.Sphere(surface_id=s['id'], x0=x0, y0=y0, z0=z0, r=b)
+            else:
+                cls = getattr(openmc, f"{s['mnemonic'][1].upper()}Torus")
+                surf = cls(surface_id=s['id'], x0=x0, y0=y0, z0=z0, a=a, b=b, c=c)
         elif s['mnemonic'] in ('x', 'y', 'z'):
             axis = s['mnemonic'].upper()
             cls_plane = getattr(openmc, f'{axis}Plane')

--- a/src/openmc_mcnp_adapter/openmc_conversion.py
+++ b/src/openmc_mcnp_adapter/openmc_conversion.py
@@ -303,7 +303,11 @@ def get_openmc_surfaces(surfaces, data):
                                   f=f, g=g, h=h, j=j, k=k)
         elif s['mnemonic'] in ('tx', 'ty', 'tz'):
             x0, y0, z0, a, b, c = coeffs
-            if a == 0 and b == c:
+            if isclose(a, 0.0, abs_tol=1e-12) and isclose(b, c):
+                warnings.warn(
+                    f"Degenerate torus surface {s['id']} (A=0, B=C) converted "
+                    f"to an openmc.Sphere of radius {b}."
+                )
                 surf = openmc.Sphere(surface_id=s['id'], x0=x0, y0=y0, z0=z0, r=b)
             else:
                 cls = getattr(openmc, f"{s['mnemonic'][1].upper()}Torus")

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -7,7 +7,7 @@ from openmc.model.surface_composite import OrthogonalBox, \
     RectangularParallelepiped, RightCircularCylinder, ConicalFrustum, \
     XConeOneSided, YConeOneSided, ZConeOneSided
 from openmc_mcnp_adapter import mcnp_str_to_model, get_openmc_surfaces
-from pytest import approx, mark, raises
+from pytest import approx, mark, raises, warns
 
 
 def convert_surface(mnemonic: str, params: Sequence[float]) -> openmc.Surface:
@@ -325,7 +325,8 @@ def test_torus(mnemonic, expected_type):
 
 @mark.parametrize("mnemonic", ["tx", "ty", "tz"])
 def test_torus_degenerate_sphere(mnemonic):
-    surf = convert_surface(mnemonic, (1.0, 2.0, 3.0, 0.0, 0.5, 0.5))
+    with warns(UserWarning, match="Degenerate torus"):
+        surf = convert_surface(mnemonic, (1.0, 2.0, 3.0, 0.0, 0.5, 0.5))
     assert isinstance(surf, openmc.Sphere)
     assert (surf.x0, surf.y0, surf.z0, surf.r) == approx((1.0, 2.0, 3.0, 0.5))
 

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -323,6 +323,13 @@ def test_torus(mnemonic, expected_type):
         assert getattr(surf, name) == approx(val)
 
 
+@mark.parametrize("mnemonic", ["tx", "ty", "tz"])
+def test_torus_degenerate_sphere(mnemonic):
+    surf = convert_surface(mnemonic, (1.0, 2.0, 3.0, 0.0, 0.5, 0.5))
+    assert isinstance(surf, openmc.Sphere)
+    assert (surf.x0, surf.y0, surf.z0, surf.r) == approx((1.0, 2.0, 3.0, 0.5))
+
+
 @mark.parametrize(
     "mnemonic, params, expected_type, attr, value",
     [


### PR DESCRIPTION
When an MCNP torus surface has A=0 and B=C, it geometrically degenerates to a sphere of radius B centered at (x0, y0, z0). OpenMC's torus surfaces don't accept A=0 ([see openmc-dev/openmc#3813](https://github.com/openmc-dev/openmc/pull/3813)), so these cases (rare) previously produced an invalid surface.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
Added test_torus_degenerate_sphere in tests/test_surfaces.py, parametrized over tx/ty/tz, asserting the result is an openmc.Sphere with the expected center and radius. The existing test_torus cases still pass (non-degenerate parameters continue to produce XTorus/YTorus/ZTorus).  