### PR TITLE
Support READ cards better

### DIFF
--- a/src/openmc_mcnp_adapter/parse.py
+++ b/src/openmc_mcnp_adapter/parse.py
@@ -26,12 +26,12 @@ _CELL_PARAMETERS_RE = re.compile(rf"""
 )
 
 _READ_RE = re.compile(r"""
-    ^               # Beginning of line
+    ^\s*(?!c\b)     # Beginning of line that is not a comment line
     \s*read         # Keyword
     \s.*?file       # Everything up to filename
     \s*=\s*         # = sign (required) with optional spaces
-    (\S+)           # The file name is anything without whitespace
-    .*              # Anything else until end-of-line
+    ([^$\s]+)       # The file name stops at whitespace or $
+    [^$\n]*         # Anything else until end-of-line or $
 """, re.IGNORECASE | re.VERBOSE | re.MULTILINE
 )
 

--- a/tests/test_read_file.py
+++ b/tests/test_read_file.py
@@ -19,6 +19,22 @@ def test_read_not_found():
         mcnp_str_to_model(deck)
 
 
+def test_dont_read_comments():
+    deck = textwrap.dedent("""
+        title
+        c The next line would point to an invalid file
+        c read file=/badfile.path
+        1 0 -1
+        
+        c The next line would also point to an invalid file
+        1 so 1.0  $ read file=/badfile.path
+        
+        c 
+        nps 1
+    """)
+    mcnp_str_to_model(deck)
+
+
 def test_read_recursive():
     reference = expand_read_cards(INPUT_DIR / "testReadReference.imcnp")
     trial = expand_read_cards(INPUT_DIR / "testRead.imcnp")


### PR DESCRIPTION
An enhancement to #29, #30 that prevents a subfile from being read when a valid `READ` card appears in the comments. Although [MCNP itself will try to read it](https://mcnp.discourse.group/t/error-in-comment-parsing-of-read-card/4476), that was an unintended "feature".

AI disclosure: Consulted Claude Sonnet 4.6 for the regex.